### PR TITLE
Add Snyk testing to the travis step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,10 @@ env:
     - NODE_ENV=development
 install:
     - npm install
-    # - cp _config/task.task-name.js test/mock-project/_config/task.task-name.js
-    # - cp package.json test/mock-project/package.json
-    # - cd test/mock-project
-    # - npm install
-    # - npm install gulp
-    # - cd ../..
-    # - npm install mocha -g
-    # - npm install gulp-cli -g
-# script:
-#     - mocha
+script:
+    - npm run snyk
 cache:
   directories:
     - node_modules
-    # - test/mock-project/node_modules
 git:
   depth: 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Cartridge Node Server installation [![Build Status](https://travis-ci.org/cartridge/cartridge-node-server.svg?branch=master)](https://travis-ci.org/cartridge/cartridge-node-server)
+# Cartridge Node Server installation
+[![Build Status](https://travis-ci.org/cartridge/cartridge-node-server.svg?branch=master)](https://travis-ci.org/cartridge/cartridge-node-server)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 To use this module, you will need [cartridge-cli](https://github.com/cartridge/cartridge-cli) installed and have a cartridge project setup.
 
@@ -28,14 +30,16 @@ There is no uninstall of this module, so please be sure that when choosing to in
 
 This module deletes any trace of itself from the node_modules folder and updates your package json so that it is represented if you choose to delete your node_modules and re-install.
 
-* * * 
+* * *
 
 ## Development
-### Commit message standards [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
-Try and adhere as closely as possible to the [Angular commit messages guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines).
 
-[Commitizen](https://github.com/commitizen/cz-cli) is a command line tool which can help with this:
-```sh
-npm install -g commitizen
+Please follow the instructions within the [base module development guide](https://github.com/cartridge/base-module/wiki/Development-guide) when working on this project.
+
+### Security testing
+
+This project uses [Snyk](https://snyk.io) to test for security exploits. It is checked by travis after each build, the test can be run locally by running the command:
+
+```bash
+npm run snyk
 ```
-Now, simply use `git cz` instead of `git commit` when committing.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "snyk": "snyk test"
   },
   "dependencies": {
     "cartridge-module-util": "~0.5.1"
@@ -33,6 +34,7 @@
     "fs-extra": "^0.26.7",
     "ghooks": "^1.2.1",
     "mocha": "^2.4.5",
+    "snyk": "^1.14.2",
     "validate-commit-msg": "^2.6.0"
   },
   "cartridge-node-server": {


### PR DESCRIPTION
## Description
Added Snyk security testing to the project. The test will be run on Travis and can be run locally with the following command:
```bash
npm run snyk
```

## Todos

- [x] Does this feature run on all supported platforms?
- [ ] Are there tests around this feature?
- [x] Is there documentation for this feature?

I will still need to investigate the monitor functionality, namely which email address we should have the flaws sent to
